### PR TITLE
Feature phpcs xml and pathfix

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,6 +34,8 @@ class PHPCBF {
             process.platform == "win32" ? "php-cbf.bat" : "phpcbf"
         );
 
+        this.configSearch = config.get("configSearch", false);
+
         /**
          * relative paths?
          */
@@ -94,7 +96,7 @@ class PHPCBF {
         const folder = workspace.getWorkspaceFolder(document.uri);
         const workspaceRoot = folder ? folder.uri.fsPath : null;
         const filePath = document.fileName;
-        if (true && workspaceRoot !== null && filePath !== undefined) {
+        if (this.configSearch && workspaceRoot !== null && filePath !== undefined) {
             const confFileNames = [
                 '.phpcs.xml', '.phpcs.xml.dist', 'phpcs.xml', 'phpcs.xml.dist',
                 'phpcs.ruleset.xml', 'ruleset.xml',

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
     "displayName": "phpcbf",
     "description": "PHP Code Beautifier and Fixer",
     "version": "0.0.8",
-	"publisher": "persoderlind",
-	"homepage": "https://github.com/soderlind/vscode-phpcbf",
-	"icon": "images/logo.png",
-	"license": "SEE LICENSE IN LICENSE.txt",
+    "publisher": "persoderlind",
+    "homepage": "https://github.com/soderlind/vscode-phpcbf",
+    "icon": "images/logo.png",
+    "license": "SEE LICENSE IN LICENSE.txt",
     "repository": {
         "type": "git",
         "url": "https://github.com/soderlind/vscode-phpcbf.git"
@@ -25,13 +25,11 @@
     ],
     "main": "./extension",
     "contributes": {
-        "commands": [
-            {
-                "command": "phpcbf-soderlind",
-                "title": "PHP Code Beautifier and Fixer: Fix this file",
-                "when": "!inOutput && editorFocus && editorLangId == php"
-            }
-        ],
+        "commands": [{
+            "command": "phpcbf-soderlind",
+            "title": "PHP Code Beautifier and Fixer: Fix this file",
+            "when": "!inOutput && editorFocus && editorLangId == php"
+        }],
         "configuration": {
             "title": "PHP Code Beautifier and Fixer Configuration options",
             "type": "object",
@@ -41,6 +39,12 @@
                     "type": "string",
                     "default": "phpcbf",
                     "description": "Points to the phpcbf exectuable, eg: win: phpcbf.bat, other: phpcbf"
+                },
+                "phpcbf.configSearch": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Search for phpcs configuration files in the workspace."
                 },
                 "phpcbf.standard": {
                     "scope": "resource",


### PR DESCRIPTION
This PR fixes 3 things:

1. Integrates PR #29 

2. Fixes a bug where `phpcbf.standard` was not resolving paths correctly

3. Fixes #21. Exec path needs to be set to the project root so it can correctly search for `installed_paths` via `phpcs --config-set installed_paths <path/to/custom/coding/standard>`
