### PR TITLE
added reject() for phpcbf exit codes 0 & 3 to stop editor hanging when there are no fixable errors found

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -175,6 +175,7 @@ class PHPCBF {
                 */
                 switch (code) {
                     case 0:
+                        reject();
                         break;
                     case 1:
                     case 2:
@@ -187,6 +188,7 @@ class PHPCBF {
                         break;
                     case 3:
                         phpcbfError = true;
+                        reject();
                         break;
                     default:
                         let msgs = {


### PR DESCRIPTION
fixes #39 