### PR TITLE
[Repo Assist] fix: null activeTextEditor crash, per-document settings, \$\{workspaceFolder} in standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.0.9
+* Fix crash on activation and configuration reload when no text editor is active (`window.activeTextEditor` is `null`). Closes #35, #43.
+* Reload settings per-document on every format call, so per-folder and multi-root workspace settings are respected. Closes #36.
+* Resolve `${workspaceFolder}` and `${workspaceRoot}` variables in the `phpcbf.standard` setting. Closes #38.
+* Use `event.document.uri` (instead of `window.activeTextEditor`) in the `onWillSaveTextDocument` listener to avoid potential null-reference errors.
+
 ## 0.0.8
 * Allow configuration from `.vscode/settings.json` when in a Multi-root project. [@WraithKenny](https://github.com/WraithKenny) [#6](https://github.com/soderlind/vscode-phpcbf/pull/6)
 ## 0.0.7

--- a/extension.js
+++ b/extension.js
@@ -19,11 +19,13 @@ class PHPCBF {
         this.loadSettings();
     }
 
-    loadSettings() {
-        let config = workspace.getConfiguration(
-            "phpcbf",
-            window.activeTextEditor.document.uri
-        );
+    loadSettings(uri) {
+        // Use the provided URI (e.g. the document being formatted), fall back to
+        // the active editor, or null (global settings) if neither is available.
+        const configUri = uri ||
+            (window.activeTextEditor ? window.activeTextEditor.document.uri : null);
+
+        let config = workspace.getConfiguration("phpcbf", configUri);
         if (!config.get("enable") === true) {
             return;
         }
@@ -58,6 +60,17 @@ class PHPCBF {
         }
 
         this.standard = config.get("standard", null);
+
+        // Resolve ${workspaceFolder} / ${workspaceRoot} in the standard path.
+        if (this.standard && configUri) {
+            const folder = workspace.getWorkspaceFolder(configUri);
+            const rootPath = folder ? folder.uri.fsPath : null;
+            if (rootPath) {
+                this.standard = this.standard
+                    .replace("${workspaceFolder}", rootPath)
+                    .replace("${workspaceRoot}", rootPath);
+            }
+        }
 
         this.documentFormattingProvider = config.get(
             "documentFormattingProvider",
@@ -135,6 +148,10 @@ class PHPCBF {
     }
 
     format(document) {
+        // Reload settings scoped to this document so multi-root workspaces and
+        // per-folder settings are respected on every format call.
+        this.loadSettings(document.uri);
+
         if (this.debug) {
             console.time("phpcbf");
         }
@@ -266,12 +283,11 @@ exports.activate = context => {
 
     context.subscriptions.push(
         workspace.onWillSaveTextDocument(event => {
-            const editor = window.activeTextEditor;
             if (
                 event.document.languageId == "php" &&
                 phpcbf.onsave &&
                 workspace
-                .getConfiguration("editor", editor.document.uri)
+                .getConfiguration("editor", event.document.uri)
                 .get("formatOnSave") === false
             ) {
                 event.waitUntil(

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-phpcbf",
     "displayName": "phpcbf",
     "description": "PHP Code Beautifier and Fixer",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "publisher": "persoderlind",
     "homepage": "https://github.com/soderlind/vscode-phpcbf",
     "icon": "images/logo.png",


### PR DESCRIPTION
…ath vars

- loadSettings() no longer crashes when window.activeTextEditor is null, fixing extension activation errors (#35, #43)
- loadSettings() now accepts an optional uri parameter so it can be scoped to the document being formatted
- format() calls loadSettings(document.uri) on every invocation, ensuring per-folder settings in multi-root workspaces are honoured (#36)
- Resolve ${workspaceFolder} and ${workspaceRoot} in phpcbf.standard (#38)
- onWillSaveTextDocument uses event.document.uri instead of window.activeTextEditor to avoid potential null-reference errors

Bump version to 0.0.9.