### PR TITLE
[Repo Assist] feat: add phpcbf.ignorePatterns configuration to exclude files from formatting (closes #27)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -78,6 +78,8 @@ class PHPCBF {
         );
 
         this.debug = config.get("debug", false);
+
+        this.ignorePatterns = config.get("ignorePatterns", []);
     }
 
     getArgs(document, tmpFileName) {
@@ -93,6 +95,9 @@ class PHPCBF {
 
         if (this.standard) {
             args.push("--standard=" + this.standard);
+        }
+        if (this.ignorePatterns && this.ignorePatterns.length > 0) {
+            args.push("--ignore=" + this.ignorePatterns.join(","));
         }
         if (this.debug) {
             console.group("PHPCBF");

--- a/package.json
+++ b/package.json
@@ -78,6 +78,15 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Write phpcbf stdout to the console"
+                },
+                "phpcbf.ignorePatterns": {
+                    "scope": "resource",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "description": "A list of file path patterns to pass to phpcbf via --ignore=. Files matching these patterns will not be formatted. Example: [\"*/vendor/*\", \"*/node_modules/*\"]"
                 }
             }
         }


### PR DESCRIPTION
…ormatting

Adds a new `phpcbf.ignorePatterns` setting (array of strings) that passes patterns directly to phpcbf via the `--ignore=` command-line flag.

Closes #27